### PR TITLE
update:HIGhとLOWを反転させる定数を追加

### DIFF
--- a/SchooMyUtilities.h
+++ b/SchooMyUtilities.h
@@ -11,6 +11,9 @@
       void soundSensorBegin(int echoPin);
       int soundSensorPlotterAnalogRead(int echoPin);
       String getChipId(uint64_t mac);
+      static const int High = LOW;
+      static const int Low = HIGH;
+
     private:
       int _plotAdjust;
       int _getSoundSensorPlotterAdjustValue(int echoPin);


### PR DESCRIPTION
## 関連Issue

close　[電圧のHIGHとLOWをSchooMyUtilitiesの中で入れ替えて定義する](https://github.com/SchooMyDevelopment/schoomy_block/issues/146)

## 目的 (Why)

- LEDなどで、HIGHで消灯、LOWで点灯になっていた
- 直感的にはHIGHで点灯、LOWで消灯であり、変更してほしいという要望があったので修正

## 内容 (What)

- SchooMyUtilities.hにHIGHとLOWを入れ替える定数を用意した。

## 影響範囲（Where）

- HIGHとLOWを使っているコネクタ
- LED、ポンプ、モーターなど

## 動作確認 (How)

- ローカル環境

## Refs (レビューにあたって参考にすべき情報）(Optional)

- HIGHとLOWは予約語扱いです。今回はHighとLowにしています。
- Schoomy_blockにも修正を加えています。