### PR TITLE
update:グラフモニタ複数データ出力対応

### DIFF
--- a/SchooMyUtilities.cpp
+++ b/SchooMyUtilities.cpp
@@ -14,6 +14,29 @@ void SchooMyUtilities::serialPlotterPrint(int value, int upperLimit, int lowerLi
   Serial.println("");
 }
 
+void SchooMyUtilities::serialPlotterPrintMultiple(int upperLimit, int lowerLimit, int numValues, ...) {
+  va_list args;
+  va_start(args, numValues);
+  Serial.print("upperLimit:");
+  Serial.print(upperLimit);
+  Serial.print(",");
+  Serial.print("lowerLimit:");
+  Serial.print(lowerLimit);
+  Serial.print(",");
+  for (int i = 0; i < numValues; i++) {
+    double value = va_arg(args, double);
+    Serial.print("value");
+    Serial.print(i + 1);
+    Serial.print(":");
+    Serial.print(value);
+    if (i < numValues - 1) {
+      Serial.print(",");
+    }
+  }
+  Serial.println("");
+  va_end(args);
+}
+
 void SchooMyUtilities::soundSensorBegin(int echoPin) {
   pinMode(echoPin, INPUT);
   _plotAdjust = _getSoundSensorPlotterAdjustValue(echoPin);

--- a/SchooMyUtilities.h
+++ b/SchooMyUtilities.h
@@ -3,11 +3,12 @@
 #ifndef SchooMyUtilities_h
   #define SchooMyUtilities_h
   #include "Arduino.h"
-  
+
   class SchooMyUtilities {
     public:
       SchooMyUtilities();
       void serialPlotterPrint(int value, int upperLimit, int lowerLimit);
+      void serialPlotterPrintMultiple(int upperLimit, int lowerLimit, int numValues, ...);
       void soundSensorBegin(int echoPin);
       int soundSensorPlotterAnalogRead(int echoPin);
       String getChipId(uint64_t mac);


### PR DESCRIPTION
## 関連Issue
close https://github.com/SchooMyDevelopment/schoomy_block/issues/484

## 目的 (Why)
グラフモニタ複数データ出力対応において、SchooMyUtilitiesの修正が必要になったため

## 内容 (What)
SchooMyUtilitiesにグラフモニタ複数データ出力用関数を追加した

## 影響範囲（Where）
グラフモニタブロック
SchooMyUtilities

## 動作確認 (How)

- local環境のSchooMyUtilitiesファイルを修正し、IDEから4つのセンシングデータを同時にグラフ出力出来る事を確認した
(value1)左上：明るさセンサー
(value2)右上：明るさセンサー
(value3)左下：温度センサー
(value4)右下：湿度センサー
`scmUtils.serialPlotterPrint(100, 0,4,_sbeGetLux(A5, 1023, 5),_sbeGetLux(A1, 1023, 5),_sbeGetTemperature_5(), _sbeGetHumidity_10());`

![image (29)](https://github.com/user-attachments/assets/13b6c573-f1dc-40e2-a350-a9cbf691b54c)


## Refs (レビューにあたって参考にすべき情報）(Optional)

- 2件以上のデータを柔軟に引数として取得できるように、可変長引数を採用した
- 既存のグラフモニタブロック用の関数(1件表示限定)は今回の関数と構造が異なるため、関数を別に分ける事とした
